### PR TITLE
FEATURE: Cursor-style keyboard-driven diff review

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,6 +129,16 @@
       {
         "command": "diffus.prevFile",
         "key": "alt+["
+      },
+      {
+        "command": "diffus.acceptHunk",
+        "key": "tab",
+        "when": "diffus.cursorInHunk && editorTextFocus && !editorHasSelection && !suggestWidgetVisible && !inSnippetMode && !editorTabMovesFocus && !editorReadonly"
+      },
+      {
+        "command": "diffus.rejectHunk",
+        "key": "escape",
+        "when": "diffus.cursorInHunk && editorTextFocus && !suggestWidgetVisible && !findWidgetVisible && !inQuickOpen && !renameInputVisible && !parameterHintsVisible && !editorHasMultipleSelections"
       }
     ]
   },

--- a/src/__mocks__/vscode.ts
+++ b/src/__mocks__/vscode.ts
@@ -60,6 +60,23 @@ export const env = {
   },
 };
 
+export class CodeLens {
+  constructor(
+    public readonly range: Range,
+    public readonly command?: {
+      title: string;
+      command: string;
+      arguments?: unknown[];
+    },
+  ) {}
+}
+
+export const commands = {
+  executeCommand: vi.fn().mockResolvedValue(undefined),
+};
+
 export const window = {
   showTextDocument: vi.fn(),
+  activeTextEditor: undefined as unknown,
+  onDidChangeTextEditorSelection: vi.fn(() => ({ dispose: vi.fn() })),
 };

--- a/src/codeLensProvider.test.ts
+++ b/src/codeLensProvider.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { DiffusCodeLensProvider } from './codeLensProvider';
+import { HunkManager } from './hunkManager';
+import { DiffHunk } from './types';
+
+function makeHunk(id: string, newStart: number): DiffHunk {
+  return {
+    id,
+    sessionId: 's1',
+    oldStart: newStart,
+    oldLines: ['old'],
+    newStart,
+    newLines: ['new'],
+  };
+}
+
+function makeDocument(filePath: string) {
+  return {
+    uri: { fsPath: filePath },
+  } as { uri: { fsPath: string } };
+}
+
+describe('DiffusCodeLensProvider', () => {
+  let hunkManager: HunkManager;
+  let provider: DiffusCodeLensProvider;
+
+  beforeEach(() => {
+    hunkManager = new HunkManager();
+    provider = new DiffusCodeLensProvider(hunkManager);
+  });
+
+  it('returns no lenses for file without hunks', () => {
+    const lenses = provider.provideCodeLenses(makeDocument('unknown.ts') as never);
+    expect(lenses).toHaveLength(0);
+  });
+
+  it('returns file-level lenses and keyboard hint (no per-hunk lenses)', () => {
+    hunkManager.setHunksForFile('file.ts', 's1', [makeHunk('h1', 5), makeHunk('h2', 15)]);
+
+    const lenses = provider.provideCodeLenses(makeDocument('file.ts') as never);
+
+    // Should have: Show Diff, Accept All, Reject All, Keyboard hint = 4 lenses
+    expect(lenses).toHaveLength(4);
+
+    const titles = lenses.map((l) => l.command?.title);
+    expect(titles).toContainEqual(expect.stringContaining('Show Diff'));
+    expect(titles).toContainEqual(expect.stringContaining('Accept All'));
+    expect(titles).toContainEqual(expect.stringContaining('Reject All'));
+    expect(titles).toContainEqual(expect.stringContaining('Tab = Accept'));
+
+    // No per-hunk Accept/Reject lenses
+    const acceptLenses = lenses.filter((l) => l.command?.title === '$(check) Accept');
+    expect(acceptLenses).toHaveLength(0);
+  });
+
+  it('shows correct hunk count in Accept All / Reject All', () => {
+    hunkManager.setHunksForFile('file.ts', 's1', [
+      makeHunk('h1', 5),
+      makeHunk('h2', 15),
+      makeHunk('h3', 25),
+    ]);
+
+    const lenses = provider.provideCodeLenses(makeDocument('file.ts') as never);
+    const acceptAll = lenses.find((l) => l.command?.title?.includes('Accept All'));
+    expect(acceptAll?.command?.title).toContain('3');
+  });
+
+  it('all file-level lenses are at line 0', () => {
+    hunkManager.setHunksForFile('file.ts', 's1', [makeHunk('h1', 10)]);
+
+    const lenses = provider.provideCodeLenses(makeDocument('file.ts') as never);
+    for (const lens of lenses) {
+      expect(lens.range.start.line).toBe(0);
+    }
+  });
+});

--- a/src/codeLensProvider.ts
+++ b/src/codeLensProvider.ts
@@ -32,41 +32,25 @@ export class DiffusCodeLensProvider implements vscode.CodeLensProvider {
       }),
     );
 
-    if (sortedHunks.length > 1) {
-      codeLenses.push(
-        new vscode.CodeLens(firstRange, {
-          title: `$(check-all) Accept All (${sortedHunks.length})`,
-          command: 'diffus.acceptAllFile',
-        }),
-      );
-      codeLenses.push(
-        new vscode.CodeLens(firstRange, {
-          title: `$(discard) Reject All (${sortedHunks.length})`,
-          command: 'diffus.rejectAllFile',
-        }),
-      );
-    }
+    codeLenses.push(
+      new vscode.CodeLens(firstRange, {
+        title: `$(check-all) Accept All (${sortedHunks.length})`,
+        command: 'diffus.acceptAllFile',
+      }),
+    );
+    codeLenses.push(
+      new vscode.CodeLens(firstRange, {
+        title: `$(discard) Reject All (${sortedHunks.length})`,
+        command: 'diffus.rejectAllFile',
+      }),
+    );
 
-    for (const hunk of sortedHunks) {
-      const lensLine = Math.max(0, hunk.newStart - 1);
-      const range = new vscode.Range(lensLine, 0, lensLine, 0);
-
-      codeLenses.push(
-        new vscode.CodeLens(range, {
-          title: '$(check) Accept',
-          command: 'diffus.acceptHunk',
-          arguments: [hunk.id],
-        }),
-      );
-
-      codeLenses.push(
-        new vscode.CodeLens(range, {
-          title: '$(x) Reject',
-          command: 'diffus.rejectHunk',
-          arguments: [hunk.id],
-        }),
-      );
-    }
+    codeLenses.push(
+      new vscode.CodeLens(firstRange, {
+        title: '$(keyboard) Tab = Accept | Esc = Reject',
+        command: '',
+      }),
+    );
 
     return codeLenses;
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 export const DEBOUNCE_MS = 300;
+export const AUTO_OPEN_DEBOUNCE_MS = 500;
 
 export const MAX_FILE_SIZE = 1 * 1024 * 1024; // 1 MB
 

--- a/src/cursorTracker.test.ts
+++ b/src/cursorTracker.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CursorTracker } from './cursorTracker';
+import { HunkManager } from './hunkManager';
+import { DiffHunk } from './types';
+import { commands, window } from 'vscode';
+
+function makeHunk(id: string, newStart: number, newLinesCount = 3): DiffHunk {
+  return {
+    id,
+    sessionId: 's1',
+    oldStart: newStart,
+    oldLines: Array(newLinesCount).fill('old'),
+    newStart,
+    newLines: Array(newLinesCount).fill('new'),
+  };
+}
+
+describe('CursorTracker', () => {
+  let hunkManager: HunkManager;
+  let tracker: CursorTracker;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hunkManager = new HunkManager();
+    (window as { activeTextEditor: unknown }).activeTextEditor = undefined;
+    tracker = new CursorTracker(hunkManager);
+  });
+
+  it('returns undefined hunkId when no hunks exist', () => {
+    expect(tracker.getCurrentHunkId()).toBeUndefined();
+  });
+
+  it('update() sets cursorInHunk to false when no active editor', () => {
+    tracker.update();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'diffus.cursorInHunk',
+      false,
+    );
+  });
+
+  it('dispose clears context key', () => {
+    tracker.dispose();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'diffus.cursorInHunk',
+      false,
+    );
+  });
+
+  it('update() sets cursorInHunk to true when cursor is in a hunk', () => {
+    hunkManager.setHunksForFile('/test/file.ts', 's1', [makeHunk('h1', 5)]);
+
+    (window as { activeTextEditor: unknown }).activeTextEditor = {
+      document: { uri: { fsPath: '/test/file.ts' } },
+      selection: { active: { line: 5 } },
+    };
+
+    tracker.update();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith('setContext', 'diffus.cursorInHunk', true);
+    expect(tracker.getCurrentHunkId()).toBe('h1');
+  });
+
+  it('update() sets cursorInHunk to false when cursor is outside hunk', () => {
+    hunkManager.setHunksForFile('/test/file.ts', 's1', [makeHunk('h1', 5)]);
+
+    (window as { activeTextEditor: unknown }).activeTextEditor = {
+      document: { uri: { fsPath: '/test/file.ts' } },
+      selection: { active: { line: 100 } },
+    };
+
+    tracker.update();
+
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'diffus.cursorInHunk',
+      false,
+    );
+    expect(tracker.getCurrentHunkId()).toBeUndefined();
+  });
+});

--- a/src/cursorTracker.ts
+++ b/src/cursorTracker.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+import { HunkManager } from './hunkManager';
+
+export class CursorTracker {
+  private disposables: vscode.Disposable[] = [];
+  private currentHunkId: string | undefined;
+
+  constructor(private hunkManager: HunkManager) {
+    this.disposables.push(
+      vscode.window.onDidChangeTextEditorSelection((e) => {
+        this.updateForEditor(e.textEditor);
+      }),
+    );
+  }
+
+  /** Force-update the context key for the current active editor */
+  update(): void {
+    const editor = vscode.window.activeTextEditor;
+    if (editor) {
+      this.updateForEditor(editor);
+    } else {
+      this.setInHunk(false);
+    }
+  }
+
+  getCurrentHunkId(): string | undefined {
+    return this.currentHunkId;
+  }
+
+  private updateForEditor(editor: vscode.TextEditor): void {
+    const filePath = editor.document.uri.fsPath;
+    const cursorLine = editor.selection.active.line + 1; // 1-based
+    const hunk = this.hunkManager.getHunkAtLine(filePath, cursorLine);
+
+    if (hunk) {
+      this.currentHunkId = hunk.id;
+      this.setInHunk(true);
+    } else {
+      this.currentHunkId = undefined;
+      this.setInHunk(false);
+    }
+  }
+
+  private setInHunk(value: boolean): void {
+    vscode.commands.executeCommand('setContext', 'diffus.cursorInHunk', value);
+  }
+
+  dispose(): void {
+    this.setInHunk(false);
+    this.disposables.forEach((d) => d.dispose());
+  }
+}

--- a/src/decorationManager.ts
+++ b/src/decorationManager.ts
@@ -33,7 +33,7 @@ export class DecorationManager {
       isWholeLine: true,
       overviewRulerColor: REMOVED_LINE_BG_OVERVIEW,
       overviewRulerLane: vscode.OverviewRulerLane.Full,
-      borderWidth: '0 0 2px 0',
+      borderWidth: '0 0 2px 3px',
       borderStyle: 'solid',
       borderColor: REMOVED_LINE_BORDER,
     });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,10 +16,13 @@ import { computeDecorationRanges } from './rangeCalculator';
 import { Ignore } from 'ignore';
 import { loadGitignoreFilter } from './fileUtils';
 import { copyPathForClaude } from './copyPathCommand';
+import { CursorTracker } from './cursorTracker';
+import { AUTO_OPEN_DEBOUNCE_MS } from './constants';
 
 let state = TrackingState.Idle;
 let activeSessionId: string | undefined;
 let isProcessingHunk = false;
+let autoOpenTimer: NodeJS.Timeout | undefined;
 
 let snapshotManager: SnapshotManager;
 let hunkManager: HunkManager;
@@ -31,6 +34,7 @@ let statusBarManager: StatusBarManager;
 let storageManager: StorageManager;
 let snapshotContentProvider: SnapshotContentProvider;
 let diffViewManager: DiffViewManager;
+let cursorTracker: CursorTracker;
 
 export function activate(context: vscode.ExtensionContext): void {
   storageManager = new StorageManager();
@@ -43,6 +47,7 @@ export function activate(context: vscode.ExtensionContext): void {
   diffViewManager = new DiffViewManager();
 
   codeLensProvider = new DiffusCodeLensProvider(hunkManager);
+  cursorTracker = new CursorTracker(hunkManager);
 
   // Register snapshot content provider for diff view
   context.subscriptions.push(
@@ -84,6 +89,7 @@ export function activate(context: vscode.ExtensionContext): void {
         navigationManager.syncToActiveEditor(editor);
         applyDecorationsToEditor(editor);
       }
+      cursorTracker.update();
       updateContextKeys();
       statusBarManager.update(state, hunkManager.getChangedFileCount());
     }),
@@ -92,6 +98,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Track hunk changes for UI updates
   context.subscriptions.push(
     hunkManager.onDidChange((changedFilePath) => {
+      cursorTracker.update();
       updateContextKeys();
       statusBarManager.update(state, hunkManager.getChangedFileCount());
       const editor = vscode.window.activeTextEditor;
@@ -115,6 +122,7 @@ export function activate(context: vscode.ExtensionContext): void {
     statusBarManager,
     snapshotContentProvider,
     diffViewManager,
+    cursorTracker,
   );
 }
 
@@ -161,6 +169,7 @@ async function restorePersistedState(): Promise<void> {
         gitignoreFilters,
       );
       watcherManager.start();
+      subscribeToAutoOpen();
       state = TrackingState.Tracking;
     } else if (hunkManager.hasChanges()) {
       state = TrackingState.StoppedWithPending;
@@ -190,6 +199,7 @@ async function startTracking(): Promise<void> {
     gitignoreFilters,
   );
   watcherManager.start();
+  subscribeToAutoOpen();
 
   state = TrackingState.Tracking;
   updateContextKeys();
@@ -298,7 +308,8 @@ async function acceptHunk(hunkId?: string): Promise<void> {
   }
 
   reapplyDecorations(filePath);
-  checkAllResolved(filePath);
+  await checkAllResolved(filePath);
+  await navigateToNextHunk(filePath);
 }
 
 async function rejectHunk(hunkId?: string): Promise<void> {
@@ -390,7 +401,8 @@ async function rejectHunk(hunkId?: string): Promise<void> {
   }
 
   reapplyDecorations(filePath);
-  checkAllResolved(filePath);
+  await checkAllResolved(filePath);
+  await navigateToNextHunk(filePath);
 }
 
 async function acceptAllFile(): Promise<void> {
@@ -421,7 +433,8 @@ async function acceptAllFile(): Promise<void> {
     isProcessingHunk = false;
   }
 
-  checkAllResolved(filePath);
+  await checkAllResolved(filePath);
+  await navigateToNextHunk(filePath);
 }
 
 async function rejectAllFile(): Promise<void> {
@@ -473,7 +486,49 @@ async function rejectAllFile(): Promise<void> {
     setSelfEditing(false);
   }
 
-  checkAllResolved(filePath);
+  await checkAllResolved(filePath);
+  await navigateToNextHunk(filePath);
+}
+
+async function navigateToNextHunk(filePath: string): Promise<void> {
+  const remaining = hunkManager.getAllHunksForFile(filePath);
+  if (remaining.length > 0) {
+    await navigationManager.navigateToHunk(filePath, remaining[0].newStart);
+  } else {
+    const next = hunkManager.getNextHunk(filePath, Infinity);
+    if (next) {
+      await navigationManager.navigateToHunk(next.filePath, next.hunk.newStart);
+    }
+  }
+}
+
+function subscribeToAutoOpen(): void {
+  if (!watcherManager) {
+    return;
+  }
+  watcherManager.onDidDetectChanges(() => {
+    if (state !== TrackingState.Tracking) {
+      return;
+    }
+    if (autoOpenTimer) {
+      clearTimeout(autoOpenTimer);
+    }
+    autoOpenTimer = setTimeout(() => {
+      autoOpenTimer = undefined;
+      // Don't auto-open if user is already viewing a changed file
+      const editor = vscode.window.activeTextEditor;
+      if (editor && hunkManager.fileHasChanges(editor.document.uri.fsPath)) {
+        return;
+      }
+      const files = hunkManager.getChangedFiles();
+      if (files.length > 0) {
+        const hunks = hunkManager.getAllHunksForFile(files[0]);
+        if (hunks.length > 0) {
+          navigationManager.navigateToHunk(files[0], hunks[0].newStart);
+        }
+      }
+    }, AUTO_OPEN_DEBOUNCE_MS);
+  });
 }
 
 function applyDecorationsToEditor(editor: vscode.TextEditor): void {

--- a/src/fileSystemWatcher.ts
+++ b/src/fileSystemWatcher.ts
@@ -11,6 +11,10 @@ export class FileSystemWatcherManager {
   private debounceTimers: Map<string, NodeJS.Timeout> = new Map();
   private disposables: vscode.Disposable[] = [];
 
+  private _onDidDetectChanges = new vscode.EventEmitter<string>();
+  /** Fires after a file change is processed and hunks are detected */
+  readonly onDidDetectChanges = this._onDidDetectChanges.event;
+
   /** Set to true when the extension itself is making edits (to avoid recursion) */
   selfEditing = false;
 
@@ -102,6 +106,9 @@ export class FileSystemWatcherManager {
 
       const hunks = computeHunks(snapshotContent, currentContent, this.activeSessionId, filePath);
       this.hunkManager.setHunksForFile(filePath, this.activeSessionId, hunks);
+      if (hunks.length > 0) {
+        this._onDidDetectChanges.fire(filePath);
+      }
     } catch {
       // File might have been deleted between event and processing
     }
@@ -129,5 +136,6 @@ export class FileSystemWatcherManager {
 
   dispose(): void {
     this.stop();
+    this._onDidDetectChanges.dispose();
   }
 }

--- a/src/hunkManager.test.ts
+++ b/src/hunkManager.test.ts
@@ -162,6 +162,56 @@ describe('HunkManager', () => {
     });
   });
 
+  describe('getNextHunk', () => {
+    it('returns next hunk in same file', () => {
+      const h1 = makeHunk('h1', 's1', 5);
+      const h2 = makeHunk('h2', 's1', 15);
+      manager.setHunksForFile('file.ts', 's1', [h1, h2]);
+
+      const result = manager.getNextHunk('file.ts', 5);
+      expect(result).toBeDefined();
+      expect(result!.hunk.id).toBe('h2');
+      expect(result!.filePath).toBe('file.ts');
+    });
+
+    it('returns first hunk of next file when no more hunks in current file', () => {
+      const h1 = makeHunk('h1', 's1', 5);
+      const h2 = makeHunk('h2', 's1', 3);
+      manager.setHunksForFile('a.ts', 's1', [h1]);
+      manager.setHunksForFile('b.ts', 's1', [h2]);
+
+      const result = manager.getNextHunk('a.ts', 100);
+      expect(result).toBeDefined();
+      expect(result!.hunk.id).toBe('h2');
+      expect(result!.filePath).toBe('b.ts');
+    });
+
+    it('returns undefined when no hunks remain anywhere', () => {
+      expect(manager.getNextHunk('file.ts', 1)).toBeUndefined();
+    });
+
+    it('returns first hunk if afterLine is before all hunks', () => {
+      const h1 = makeHunk('h1', 's1', 10);
+      manager.setHunksForFile('file.ts', 's1', [h1]);
+
+      const result = manager.getNextHunk('file.ts', 1);
+      expect(result).toBeDefined();
+      expect(result!.hunk.id).toBe('h1');
+    });
+
+    it('wraps to first file when current is last file', () => {
+      const h1 = makeHunk('h1', 's1', 5);
+      const h2 = makeHunk('h2', 's1', 3);
+      manager.setHunksForFile('a.ts', 's1', [h1]);
+      manager.setHunksForFile('b.ts', 's1', [h2]);
+
+      const result = manager.getNextHunk('b.ts', 100);
+      expect(result).toBeDefined();
+      expect(result!.hunk.id).toBe('h1');
+      expect(result!.filePath).toBe('a.ts');
+    });
+  });
+
   describe('getSessionIdsForFile', () => {
     it('returns session IDs for a file', () => {
       manager.setHunksForFile('file.ts', 's1', [makeHunk('h1', 's1')]);

--- a/src/hunkManager.ts
+++ b/src/hunkManager.ts
@@ -116,6 +116,47 @@ export class HunkManager {
     return undefined;
   }
 
+  /** Get the next hunk after the given line in the same file, or the first hunk in the next changed file */
+  getNextHunk(
+    filePath: string,
+    afterLine: number,
+  ): { hunk: DiffHunk; filePath: string } | undefined {
+    // Try same file first
+    const hunks = this.getAllHunksForFile(filePath);
+    const next = hunks.find((h) => h.newStart > afterLine);
+    if (next) {
+      return { hunk: next, filePath };
+    }
+
+    // Try next changed file
+    const files = this.getChangedFiles();
+    const currentIdx = files.indexOf(filePath);
+    if (currentIdx === -1 && files.length > 0) {
+      const firstHunks = this.getAllHunksForFile(files[0]);
+      if (firstHunks.length > 0) {
+        return { hunk: firstHunks[0], filePath: files[0] };
+      }
+    }
+
+    for (let i = 1; i <= files.length; i++) {
+      const nextFile = files[(currentIdx + i) % files.length];
+      if (nextFile === filePath) {
+        // Wrapped around, check if there are remaining hunks at start of same file
+        const remaining = this.getAllHunksForFile(filePath);
+        if (remaining.length > 0) {
+          return { hunk: remaining[0], filePath };
+        }
+        return undefined;
+      }
+      const nextHunks = this.getAllHunksForFile(nextFile);
+      if (nextHunks.length > 0) {
+        return { hunk: nextHunks[0], filePath: nextFile };
+      }
+    }
+
+    return undefined;
+  }
+
   getSessionIdsForFile(filePath: string): string[] {
     const states = this.fileStates.get(filePath);
     return states?.map((s) => s.sessionId) ?? [];

--- a/src/navigationManager.ts
+++ b/src/navigationManager.ts
@@ -26,6 +26,22 @@ export class NavigationManager {
     await this.openFile(files[this.currentIndex]);
   }
 
+  /** Open a file and position the cursor at the given 1-based line */
+  async navigateToHunk(filePath: string, line: number): Promise<void> {
+    try {
+      const doc = await vscode.workspace.openTextDocument(filePath);
+      const editor = await vscode.window.showTextDocument(doc);
+      const position = new vscode.Position(Math.max(0, line - 1), 0);
+      editor.selection = new vscode.Selection(position, position);
+      editor.revealRange(
+        new vscode.Range(position, position),
+        vscode.TextEditorRevealType.InCenterIfOutsideViewport,
+      );
+    } catch {
+      // File might have been deleted
+    }
+  }
+
   private async openFile(filePath: string): Promise<void> {
     try {
       const doc = await vscode.workspace.openTextDocument(filePath);


### PR DESCRIPTION
- Add Tab to accept hunk, Escape to reject (with precise when-clauses so they don't interfere with autocomplete, snippets, find, etc.)
- Auto-navigate to next hunk after accept/reject (same file or next file)
- Auto-open first changed file when watcher detects AI changes (500ms debounce)
- Add cursor-in-hunk tracking via context key diffus.cursorInHunk
- Simplify CodeLens: remove per-hunk buttons, keep file-level actions + keyboard hint
- Add red left border to deletion markers for better gutter visibility
- Add 14 new tests (cursorTracker, codeLensProvider, hunkManager.getNextHunk)

https://claude.ai/code/session_01CKEZXMYnftLQ4Sh5vZLjwv